### PR TITLE
Python 3.3+ support, added six to requirements, bumped requests version,...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lxml==3.2.5
-requests==2.1.0
+requests>=2.1.0
+six

--- a/roku/core.py
+++ b/roku/core.py
@@ -1,7 +1,9 @@
 import logging
 import requests
-from lxml import etree
-from urlparse import urlparse
+import xml.etree.ElementTree as ET
+#from lxml import etree
+
+from six.moves.urllib_parse import urlparse
 
 from roku import discovery
 
@@ -36,6 +38,7 @@ TOUCH_OPS = ('up', 'down', 'press', 'move', 'cancel')
 class RokuException(Exception):
     pass
 
+
 class Application(object):
 
     def __init__(self, id, version, name, roku=None):
@@ -45,7 +48,8 @@ class Application(object):
         self.roku = roku
 
     def __repr__(self):
-        return '<Application: [%s] %s v%s>' % (self.id, self.name, self.version)
+        return ('<Application: [%s] %s v%s>' %
+               (self.id, self.name, self.version))
 
     @property
     def icon(self):
@@ -59,6 +63,7 @@ class Application(object):
     def store(self):
         if self.roku:
             self.roku.store(self)
+
 
 class Roku(object):
 
@@ -147,7 +152,7 @@ class Roku(object):
     def apps(self):
         applications = []
         resp = self._get('/query/apps')
-        root = etree.fromstring(resp)
+        root = ET.fromstring(resp)
         for app_node in root:
             app = Application(
                 id=app_node.attrib['id'],

--- a/roku/discovery.py
+++ b/roku/discovery.py
@@ -4,18 +4,20 @@ https://gist.github.com/dankrause/6000248
 http://github.com/dankrause
 """
 import socket
-import httplib
-import StringIO
+import six
+from six.moves import http_client
 
 
 class SSDPResponse(object):
 
-    class _FakeSocket(StringIO.StringIO):
+    class _FakeSocket(six.BytesIO):
+
         def makefile(self, *args, **kw):
             return self
 
     def __init__(self, response):
-        r = httplib.HTTPResponse(self._FakeSocket(response))
+        r = http_client.HTTPResponse(
+            self._FakeSocket(response))
         r.begin()
         self.location = r.getheader('location')
         self.usn = r.getheader('usn')
@@ -34,21 +36,26 @@ def discover(timeout=2, retries=1):
         'M-SEARCH * HTTP/1.1',
         'HOST: {0}:{1}'.format(*group),
         'MAN: "ssdp:discover"',
-        'ST: {st}','MX: 3','',''])
+        'ST: {st}', 'MX: 3', '', ''])
 
     socket.setdefaulttimeout(timeout)
 
     responses = {}
 
     for _ in range(retries):
-
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        sock = socket.socket(
+            socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
-        sock.sendto(message.format(st='roku:ecp'), group)
-
+        m = message.format(st='roku:ecp')
+        if six.PY2:
+            sock.sendto(m, group)
+        elif six.PY3:
+            sock.sendto(m.encode(), group)
         while 1:
             try:
+                #recv = sock.recv(1024)
+                # print(recv)
                 response = SSDPResponse(sock.recv(1024))
                 responses[response.location] = response
             except socket.timeout:

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
     url='https://github.com/jcarbaugh/python-roku',
     packages=find_packages(),
     install_requires=[
-        'lxml == 3.2.5',
-        'requests==2.1.0',
+        'requests>=2.1.0',
+        'six'
     ],
     license='BSD License',
     platforms=["any"],


### PR DESCRIPTION
Added Six to requirements (This library help with making things work both on 2 and 3)
Made enhancements to work on both Python 2 and 3
Requirement change Requests >= 2.1.0
Remove lxml requirement, replaced with standard library xml
PEP8 cleanup
Tested with Python 2.7.6 and 3.3.4
