### PR TITLE
Added query for device info

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -177,7 +177,7 @@ class Roku(object):
         return applications
 
     @property
-    def devinfo(self):
+    def device_info(self):
         resp = self._get('/query/device-info')
         root = ET.fromstring(resp)
 

--- a/roku/core.py
+++ b/roku/core.py
@@ -64,6 +64,19 @@ class Application(object):
             self.roku.store(self)
 
 
+class DeviceInfo(object):
+
+    def __init__(self, modelname, modelnum, swversion, sernum):
+        self.modelname = modelname
+        self.modelnum = modelnum
+        self.swversion = swversion
+        self.sernum = sernum
+
+    def __repr__(self):
+        return ('<DeviceInfo: %s-%s, SW v%s, Ser# %s>' %
+                (self.modelname, self.modelnum, self.swversion, self.sernum))
+
+
 class Roku(object):
 
     @classmethod
@@ -162,6 +175,23 @@ class Roku(object):
             )
             applications.append(app)
         return applications
+
+    @property
+    def devinfo(self):
+        resp = self._get('/query/device-info')
+        root = ET.fromstring(resp)
+
+        dinfo = DeviceInfo(
+            modelname=root.find('model-name').text,
+            modelnum=root.find('model-number').text,
+            swversion=''.join([
+                root.find('software-version').text,
+                '.',
+                root.find('software-build').text
+            ]),
+            sernum=root.find('serial-number').text
+        )
+        return dinfo
 
     @property
     def commands(self):

--- a/roku/tests.py
+++ b/roku/tests.py
@@ -93,7 +93,7 @@ class RokuTestCase(unittest.TestCase):
 
     def testDeviceInfo(self):
 
-        d = self.roku.devinfo
+        d = self.roku.device_info
 
         self.assertEqual(d.modelname, 'Roku 3')
         self.assertEqual(d.modelnum, '4200X')

--- a/roku/tests.py
+++ b/roku/tests.py
@@ -7,6 +7,37 @@ TEST_APPS = (
     ('33', '3.0.3', 'Fake YouTube'),
 )
 
+TEST_DEV_INFO = ''.join([
+    '<?xml version="1.0" encoding="UTF-8" ?>',
+    '<device-info>',
+    '    <udn>00000000-1111-2222-3333-444444444444</udn>',
+    '    <serial-number>111111111111</serial-number>',
+    '    <device-id>222222222222</device-id>',
+    '    <vendor-name>Roku</vendor-name>',
+    '    <model-number>4200X</model-number>',
+    '    <model-name>Roku 3</model-name>',
+    '    <wifi-mac>00:11:22:33:44:55</wifi-mac>',
+    '    <ethernet-mac>00:11:22:33:44:56</ethernet-mac>',
+    '    <network-type>ethernet</network-type>',
+    '    <user-device-name/>',
+    '    <software-version>7.00</software-version>',
+    '    <software-build>09044</software-build>',
+    '    <secure-device>true</secure-device>',
+    '    <language>en</language>',
+    '    <country>US</country>',
+    '    <locale>en_US</locale>',
+    '    <time-zone>US/Eastern</time-zone>',
+    '    <time-zone-offset>-300</time-zone-offset>',
+    '    <power-mode>PowerOn</power-mode>',
+    '    <developer-enabled>false</developer-enabled>',
+    '    <search-enabled>true</search-enabled>',
+    '    <voice-search-enabled>true</voice-search-enabled>',
+    '    <notifications-enabled>true</notifications-enabled>',
+    '    <notifications-first-use>false</notifications-first-use>',
+    '    <headphones-connected>false</headphones-connected>',
+    '</device-info>'
+])
+
 
 class TestRoku(Roku):
 
@@ -21,6 +52,8 @@ class TestRoku(Roku):
         if path == '/query/apps':
             fmt = '<app id="%s" version="%s">%s</app>'
             resp = '<apps>%s</apps>' % "".join(fmt % a for a in TEST_APPS)
+        elif path == '/query/device-info':
+            resp = TEST_DEV_INFO
 
         self._calls.append((method, path, args, kwargs, resp))
 
@@ -57,6 +90,15 @@ class RokuTestCase(unittest.TestCase):
         self.assertEqual(app.id, TEST_APPS[2][0])
         self.assertEqual(app.version, TEST_APPS[2][1])
         self.assertEqual(app.name, TEST_APPS[2][2])
+
+    def testDeviceInfo(self):
+
+        d = self.roku.devinfo
+
+        self.assertEqual(d.modelname, 'Roku 3')
+        self.assertEqual(d.modelnum, '4200X')
+        self.assertEqual(d.swversion, '7.00.09044')
+        self.assertEqual(d.sernum, '111111111111')
 
     def testCommands(self):
 


### PR DESCRIPTION
Added devinfo() to Roku class in core.py, which issues a GET on 'query/device-info' and parses out a few interesting fields. 

This allows me to resolve ncmiller/roku-cli/issues/1.