### PR TITLE
Adding volume commands for Roku TV support.

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -27,6 +27,9 @@ COMMANDS = {
     'search': 'Search',
     'enter': 'Enter',
     'literal': 'Lit',
+    'volumeup': 'VolumeUp',
+    'volumedown': 'VolumeDown',
+    'mute': 'VolumeMute',
 }
 
 SENSORS = ('acceleration', 'magnetic', 'orientation', 'rotation')


### PR DESCRIPTION
Some roku devices such as the Roku TV's also have volume control. 

https://sdkdocs.roku.com/display/sdkdoc/External+Control+Guide#ExternalControlGuide-3.4Keypresskeyvalues
