### PR TITLE
Add lowercase + symbol literal input support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,10 @@ Okay, I've already seen all of the available episodes of Nashville, so I'm going
 
     >>> roku.literal('stargate')
 
+What if I now want to watch *The Informant!*? Again, with the search open and waiting for text entry::
+
+    >>> roku.literal('The Informant!')
+
 This will iterate over each character, sending it individually to the Roku.
 
 

--- a/roku/core.py
+++ b/roku/core.py
@@ -7,6 +7,11 @@ from six.moves.urllib_parse import urlparse
 from . import discovery
 from .util import deserialize_apps
 
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus
+
 
 __version__ = '3.0.0'
 
@@ -117,7 +122,7 @@ class Roku(object):
                 self.input(params)
             elif name == 'literal':
                 for char in args[0]:
-                    path = '/keypress/%s_%s' % (COMMANDS[name], char.upper())
+                    path = '/keypress/%s_%s' % (COMMANDS[name], quote_plus(char))
                     self._post(path)
             else:
                 path = '/keypress/%s' % COMMANDS[name]

--- a/roku/tests/test_roku.py
+++ b/roku/tests/test_roku.py
@@ -1,6 +1,12 @@
+# -*- coding: utf-8 -*-
 import os
 
 import pytest
+
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus
 
 from roku.core import Application, Roku, COMMANDS
 from roku.util import serialize_apps
@@ -105,7 +111,16 @@ def test_literal(roku):
     roku.literal(text)
 
     for i, call in enumerate(roku.calls()):
-        assert call == ('POST', '/keypress/Lit_%s' % text[i].upper(), (), {})
+        assert call == ('POST', '/keypress/Lit_%s' % quote_plus(text[i]), (), {})
+
+
+def test_literal_fancy(roku):
+
+    text = r"""~!@#$%^&*()_+`-=[]{};':",./<>?\|€£"""
+    roku.literal(text)
+
+    for i, call in enumerate(roku.calls()):
+        assert call == ('POST', '/keypress/Lit_%s' % quote_plus(text[i]), (), {})
 
 
 def test_store(apps):


### PR DESCRIPTION
According to the [documentation](https://sdkdocs.roku.com/display/sdkdoc/External+Control+Guide#ExternalControlGuide-keydown/key):

> When the current screen on the Roku box includes an on-screen keyboard, any keyboard character can be sent via the keyup, keydown, and keypress commands. The key parameter can either be a key name, such as the name of a button on a remote control, or a printable character value specified with the prefix "Lit_".
> 
> Printable ASCII character code values can be transmitted "as-is" with the "Lit_" prefix. For example, you can send a 'r' with "Lit_r". In addition, any UTF-8 encoded character can be sent by URL-encoding it. For example, the euro symbol can be sent with "Lit_%E2%82%AC".

As a result, I modified `core.py` to include lowercase and symbol support. I've tested this with the Roku 2 XD, and lowercase letters + symbols now work!