### PR TITLE
expose the power state element from device-info

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -209,7 +209,7 @@ class Roku(object):
 
     @property
     def power_mode(self):
-        resp = self.__get('/query/device-info')
+        resp = self._get('/query/device-info')
         root = ET.fromstring(resp)
         return root.find('power-mode').text
 

--- a/roku/core.py
+++ b/roku/core.py
@@ -208,6 +208,12 @@ class Roku(object):
         return applications
 
     @property
+    def power_mode(self):
+        resp = self.__get('/query/device-info')
+        root = ET.fromstring(resp)
+        return root.find('power-mode').text
+
+    @property
     def device_info(self):
         resp = self._get('/query/device-info')
         root = ET.fromstring(resp)


### PR DESCRIPTION
expose the power-state element from device-info.  This can be used to determine if a roku tv is powered on or not.