### PR TITLE
Support for launching tv tuner and optionally changing channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 dist/
 .vagrant
 build
-roku.egg-info
+python_roku.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .DS_Store
 .env
 dist/
+.vagrant
+build
+roku.egg-info

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Installation
 
 ::
 
-    pip install roku
+    pip install python-roku
 
 
 Usage

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$bootstrapScript = <<SCRIPT
+apt-get update && apt-get install python-pip python3 python3-pip python-nose -y
+SCRIPT
+
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/wily64"
+
+  config.vm.network "public_network"
+
+  config.vm.provision "shell", inline: $bootstrapScript
+end

--- a/roku/core.py
+++ b/roku/core.py
@@ -43,10 +43,12 @@ class RokuException(Exception):
 
 class Application(object):
 
-    def __init__(self, id, version, name, roku=None):
+    def __init__(self, id, version, name, is_screensaver=False,
+                 roku=None):
         self.id = str(id)
         self.version = version
         self.name = name
+        self.is_screensaver = is_screensaver
         self.roku = roku
 
     def __repr__(self):
@@ -233,10 +235,12 @@ class Roku(object):
     def current_app(self):
         resp = self._get('/query/active-app')
         root = ET.fromstring(resp)
+        is_screensaver = True
 
         app_node = root.find('screensaver')
         if app_node is None:
             app_node = root.find('app')
+            is_screensaver = False
 
         if app_node is None:
             return None
@@ -245,5 +249,6 @@ class Roku(object):
             id=app_node.get('id'),
             version=app_node.get('version'),
             name=app_node.text,
+            is_screensaver=is_screensaver,
             roku=self,
         )

--- a/roku/core.py
+++ b/roku/core.py
@@ -6,7 +6,7 @@ from six.moves.urllib_parse import urlparse
 
 from roku import discovery
 
-__version__ = '3.1.3'
+__version__ = '3.1.4'
 
 roku_logger = logging.getLogger('roku')
 

--- a/roku/core.py
+++ b/roku/core.py
@@ -171,8 +171,8 @@ class Roku(object):
         root = ET.fromstring(resp)
         for app_node in root:
             app = Application(
-                id=app_node.attrib['id'],
-                version=app_node.attrib['version'],
+                id=app_node.get('id'),
+                version=app_node.get('version'),
                 name=app_node.text,
                 roku=self,
             )
@@ -240,8 +240,8 @@ class Roku(object):
             return None
 
         return Application(
-            id=app_node.attrib['id'],
-            version=app_node.attrib['version'],
+            id=app_node.get('id'),
+            version=app_node.get('version'),
             name=app_node.text,
             roku=self,
         )

--- a/roku/core.py
+++ b/roku/core.py
@@ -6,7 +6,7 @@ from six.moves.urllib_parse import urlparse
 
 from roku import discovery
 
-__version__ = '3.1.2'
+__version__ = '3.1.3'
 
 roku_logger = logging.getLogger('roku')
 

--- a/roku/core.py
+++ b/roku/core.py
@@ -238,6 +238,9 @@ class Roku(object):
             raise RokuException('this app belongs to another Roku')
         return self._post('/launch/%s' % app.id)
 
+    def channel(self, ch=""):
+        return self._post('/launch/tvinput.dtv?ch=%s' % ch)
+
     def store(self, app):
         return self._post('/launch/11', params={'contentID': app.id})
 

--- a/roku/core.py
+++ b/roku/core.py
@@ -6,7 +6,7 @@ from six.moves.urllib_parse import urlparse
 
 from roku import discovery
 
-__version__ = '3.1.4'
+__version__ = '3.1.5'
 
 roku_logger = logging.getLogger('roku')
 

--- a/roku/core.py
+++ b/roku/core.py
@@ -69,15 +69,16 @@ class Application(object):
 
 class DeviceInfo(object):
 
-    def __init__(self, modelname, modelnum, swversion, sernum):
+    def __init__(self, modelname, modelnum, swversion, sernum, userdevicename):
         self.modelname = modelname
         self.modelnum = modelnum
         self.swversion = swversion
         self.sernum = sernum
+        self.userdevicename = userdevicename
 
     def __repr__(self):
-        return ('<DeviceInfo: %s-%s, SW v%s, Ser# %s>' %
-                (self.modelname, self.modelnum, self.swversion, self.sernum))
+        return ('<DeviceInfo: %s-%s, SW v%s, Ser# %s, Name %s>' %
+                (self.modelname, self.modelnum, self.swversion, self.sernum, self.userdevicename))
 
 
 class Roku(object):
@@ -192,7 +193,8 @@ class Roku(object):
                 '.',
                 root.find('software-build').text
             ]),
-            sernum=root.find('serial-number').text
+            sernum=root.find('serial-number').text,
+            userdevicename=root.find('user-device-name').text
         )
         return dinfo
 
@@ -206,7 +208,7 @@ class Roku(object):
     def launch(self, app):
         if app.roku and app.roku != self:
             raise RokuException('this app belongs to another Roku')
-        return self._post('/launch/%s' % app.id, params={'contentID': app.id})
+        return self._post('/launch/%s' % app.id)
 
     def store(self, app):
         return self._post('/launch/11', params={'contentID': app.id})

--- a/roku/core.py
+++ b/roku/core.py
@@ -116,7 +116,7 @@ class Roku(object):
                     path = '/keypress/%s_%s' % (COMMANDS[name], char.upper())
                     self._post(path)
             elif name == 'search':
-                keys = ['title', 'season']
+                keys = ['title', 'season', 'launch', 'provider', 'type']
                 params = dict(zip(keys, args))
                 path = '/search/browse'
                 self._post(path, params=params)

--- a/roku/core.py
+++ b/roku/core.py
@@ -115,6 +115,11 @@ class Roku(object):
                 for char in args[0]:
                     path = '/keypress/%s_%s' % (COMMANDS[name], char.upper())
                     self._post(path)
+            elif name == 'search':
+                keys = ['title', 'season']
+                params = dict(zip(keys, args))
+                path = '/search/browse'
+                self._post(path, params=params)
             else:
                 path = '/keypress/%s' % COMMANDS[name]
                 self._post(path)

--- a/roku/core.py
+++ b/roku/core.py
@@ -11,6 +11,7 @@ __version__ = '3.1.4'
 roku_logger = logging.getLogger('roku')
 
 COMMANDS = {
+    # Standard Keys
     'home': 'Home',
     'reverse': 'Rev',
     'forward': 'Fwd',
@@ -27,9 +28,29 @@ COMMANDS = {
     'search': 'Search',
     'enter': 'Enter',
     'literal': 'Lit',
+
+    # For devices that support "Find Remote"
+    'find_remote': 'FindRemote',
+
+    # For Roku TV
     'volume_down': 'VolumeDown',
-    'volume_mute': 'VolumeMute',
     'volume_up': 'VolumeUp',
+    'volume_mute': 'VolumeMute',
+
+    # For Roku TV while on TV tuner channel
+    'channel_up': 'ChannelUp',
+    'channel_down': 'ChannelDown',
+
+    # For Roku TV current input
+    'input_tuner': 'InputTuner',
+    'input_hdmi1': 'InputHDMI1',
+    'input_hdmi2': 'InputHDMI2',
+    'input_hdmi3': 'InputHDMI3',
+    'input_hdmi4': 'InputHDMI4',
+    'input_av1': 'InputAV1',
+
+    # For devices that support being turned on/off
+    'power': 'Power'
 }
 
 SENSORS = ('acceleration', 'magnetic', 'orientation', 'rotation')

--- a/roku/core.py
+++ b/roku/core.py
@@ -27,6 +27,9 @@ COMMANDS = {
     'search': 'Search',
     'enter': 'Enter',
     'literal': 'Lit',
+    'volume_down': 'VolumeDown',
+    'volume_mute': 'VolumeMute',
+    'volume_up': 'VolumeUp',
 }
 
 SENSORS = ('acceleration', 'magnetic', 'orientation', 'rotation')
@@ -62,6 +65,19 @@ class Application(object):
     def store(self):
         if self.roku:
             self.roku.store(self)
+
+
+class DeviceInfo(object):
+
+    def __init__(self, modelname, modelnum, swversion, sernum):
+        self.modelname = modelname
+        self.modelnum = modelnum
+        self.swversion = swversion
+        self.sernum = sernum
+
+    def __repr__(self):
+        return ('<DeviceInfo: %s-%s, SW v%s, Ser# %s>' %
+                (self.modelname, self.modelnum, self.swversion, self.sernum))
 
 
 class Roku(object):
@@ -162,6 +178,23 @@ class Roku(object):
             )
             applications.append(app)
         return applications
+
+    @property
+    def device_info(self):
+        resp = self._get('/query/device-info')
+        root = ET.fromstring(resp)
+
+        dinfo = DeviceInfo(
+            modelname=root.find('model-name').text,
+            modelnum=root.find('model-number').text,
+            swversion=''.join([
+                root.find('software-version').text,
+                '.',
+                root.find('software-build').text
+            ]),
+            sernum=root.find('serial-number').text
+        )
+        return dinfo
 
     @property
     def commands(self):

--- a/roku/core.py
+++ b/roku/core.py
@@ -162,7 +162,7 @@ class Roku(object):
         func = getattr(self._conn, method.lower())
         resp = func(url, *args, **kwargs)
 
-        if resp.status_code != 200:
+        if resp.status_code not in [200, 204]:
             raise RokuException(resp.content)
 
         return resp.content

--- a/roku/core.py
+++ b/roku/core.py
@@ -6,7 +6,7 @@ from six.moves.urllib_parse import urlparse
 
 from roku import discovery
 
-__version__ = '2.0.0'
+__version__ = '3.1.2'
 
 roku_logger = logging.getLogger('roku')
 

--- a/roku/tests.py
+++ b/roku/tests.py
@@ -7,6 +7,37 @@ TEST_APPS = (
     ('33', '3.0.3', 'Fake YouTube'),
 )
 
+TEST_DEV_INFO = ''.join([
+    '<?xml version="1.0" encoding="UTF-8" ?>',
+    '<device-info>',
+    '    <udn>00000000-1111-2222-3333-444444444444</udn>',
+    '    <serial-number>111111111111</serial-number>',
+    '    <device-id>222222222222</device-id>',
+    '    <vendor-name>Roku</vendor-name>',
+    '    <model-number>4200X</model-number>',
+    '    <model-name>Roku 3</model-name>',
+    '    <wifi-mac>00:11:22:33:44:55</wifi-mac>',
+    '    <ethernet-mac>00:11:22:33:44:56</ethernet-mac>',
+    '    <network-type>ethernet</network-type>',
+    '    <user-device-name/>',
+    '    <software-version>7.00</software-version>',
+    '    <software-build>09044</software-build>',
+    '    <secure-device>true</secure-device>',
+    '    <language>en</language>',
+    '    <country>US</country>',
+    '    <locale>en_US</locale>',
+    '    <time-zone>US/Eastern</time-zone>',
+    '    <time-zone-offset>-300</time-zone-offset>',
+    '    <power-mode>PowerOn</power-mode>',
+    '    <developer-enabled>false</developer-enabled>',
+    '    <search-enabled>true</search-enabled>',
+    '    <voice-search-enabled>true</voice-search-enabled>',
+    '    <notifications-enabled>true</notifications-enabled>',
+    '    <notifications-first-use>false</notifications-first-use>',
+    '    <headphones-connected>false</headphones-connected>',
+    '</device-info>'
+])
+
 
 class TestRoku(Roku):
 
@@ -21,6 +52,8 @@ class TestRoku(Roku):
         if path == '/query/apps':
             fmt = '<app id="%s" version="%s">%s</app>'
             resp = '<apps>%s</apps>' % "".join(fmt % a for a in TEST_APPS)
+        elif path == '/query/device-info':
+            resp = TEST_DEV_INFO
 
         self._calls.append((method, path, args, kwargs, resp))
 
@@ -57,6 +90,15 @@ class RokuTestCase(unittest.TestCase):
         self.assertEqual(app.id, TEST_APPS[2][0])
         self.assertEqual(app.version, TEST_APPS[2][1])
         self.assertEqual(app.name, TEST_APPS[2][2])
+
+    def testDeviceInfo(self):
+
+        d = self.roku.device_info
+
+        self.assertEqual(d.modelname, 'Roku 3')
+        self.assertEqual(d.modelnum, '4200X')
+        self.assertEqual(d.swversion, '7.00.09044')
+        self.assertEqual(d.sernum, '111111111111')
 
     def testCommands(self):
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='roku',
-    version='3.0',
+    version='3.1.1',
     description='Client for the Roku media player',
     long_description=readme,
     author='Jeremy Carbaugh',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='python-roku',
-    version='3.1.4',
+    version='3.1.5',
     description='Client for the Roku media player',
     long_description=readme,
     author='Jeremy Carbaugh',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='roku',
-    version='3.1.1',
+    version='3.1.2',
     description='Client for the Roku media player',
     long_description=readme,
     author='Jeremy Carbaugh',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ readme = f.read()
 f.close()
 
 setup(
-    name='roku',
+    name='python-roku',
     version='3.1.3',
     description='Client for the Roku media player',
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     author='Jeremy Carbaugh',
     author_email='jcarbaugh@gmail.com',
-    url='https://github.com/jcarbaugh/python-roku',
+    url='https://github.com/bah2830/python-roku',
     packages=find_packages(),
     install_requires=[
         'requests>=2.1.0',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='roku',
-    version='3.1.2',
+    version='3.1.3',
     description='Client for the Roku media player',
     long_description=readme,
     author='Jeremy Carbaugh',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='roku',
-    version='2.0',
+    version='3.0',
     description='Client for the Roku media player',
     long_description=readme,
     author='Jeremy Carbaugh',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='python-roku',
-    version='3.1.3',
+    version='3.1.4',
     description='Client for the Roku media player',
     long_description=readme,
     author='Jeremy Carbaugh',


### PR DESCRIPTION
This adds the ability to easily launch the digital TV tuner app on a Roku TV and optionally change to a specific channel.

Example: 
```python
r = Roku('192.168.1.200')
r.channel("2.1")   # Launches TV tuner and sets channel to 2.1
r.channel()        # Launches TV tuner to the last watched channel
```



 I've tested this with a TCL Roku TV.