### PR TITLE
Add configurable timeouts to requests

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -125,10 +125,11 @@ class Roku(object):
             rokus.append(Roku(o.hostname, o.port))
         return rokus
 
-    def __init__(self, host, port=8060):
+    def __init__(self, host, port=8060, timeout=10):
         self.host = host
         self.port = port
         self._conn = None
+        self.timeout = timeout
 
     def __repr__(self):
         return "<Roku: %s:%s>" % (self.host, self.port)
@@ -192,7 +193,7 @@ class Roku(object):
             raise ValueError('only GET and POST HTTP methods are supported')
 
         func = getattr(self._conn, method.lower())
-        resp = func(url, *args, **kwargs)
+        resp = func(url, timeout=self.timeout, *args, **kwargs)
 
         if resp.status_code != 200:
             raise RokuException(resp.content)


### PR DESCRIPTION
Fixes #17.

Adds a timeout to GET and POST requests.

Default value is 10 seconds (this seemed reasonable for a potentially slow local network without being too excessively long).