### PR TITLE
Improve Roku TV power support

### DIFF
--- a/roku/tests/responses/device-info.xml
+++ b/roku/tests/responses/device-info.xml
@@ -6,6 +6,8 @@
     <vendor-name>Roku</vendor-name>
     <model-number>4200X</model-number>
     <model-name>Roku 3</model-name>
+    <is-tv>false</is-tv>
+    <is-stick>true</is-stick>
     <wifi-mac>00:11:22:33:44:55</wifi-mac>
     <ethernet-mac>00:11:22:33:44:56</ethernet-mac>
     <network-type>ethernet</network-type>

--- a/roku/tests/test_roku.py
+++ b/roku/tests/test_roku.py
@@ -89,6 +89,7 @@ def test_device_info(mocker, roku):
     assert d.model_num == '4200X'
     assert d.software_version == '7.00.09044'
     assert d.serial_num == '111111111111'
+    assert d.roku_type == 'Stick'
 
 
 def test_commands(roku):


### PR DESCRIPTION
Roku TVs can be turned on and off, but it's helpful for consumers of the
API to be able to determine whether they're talking to a TV and also to
figure out what the current state of the TV is. This patch extracts the
device type (Box, Stick or TV) from the device info and exports that, and
also provides a new power_state method to allow querying of whether the TV
is on or off. It also adds the documented PowerOff command supported on
TVs.