### PR TITLE
Added specific commands for power on and off

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -57,6 +57,8 @@ COMMANDS = {
 
     # For devices that support being turned on/off
     'power': 'Power',
+    'power_on': 'PowerOn',
+    'power_off': 'PowerOff',
 }
 
 SENSORS = ('acceleration', 'magnetic', 'orientation', 'rotation')


### PR DESCRIPTION
These commands are supported by Roku and allow for specific control over power instead of toggling.