### PR TITLE
Fix issue with Cython and Python3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url='https://github.com/jcarbaugh/python-roku',
     packages=find_packages(),
     install_requires=[
-        'lxml>=3.6,<3.7',
+        'lxml>=4.4.0,<4.5.0',
         'requests>=2.10,<2.11',
         'six'
     ],


### PR DESCRIPTION

We need lxml > 4.3.0 for Home Assistant or need revert the PR to use this library.