### PR TITLE
Unlock "requests" minor version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'lxml>=4.4.0,<4.5.0',
-        'requests>=2.10,<2.11',
+        'requests>=2.10,<3',
         'six'
     ],
     license='BSD License',


### PR DESCRIPTION
It does not seem that this library actually requires `requests` `2.10` specifically, and a newer `2.22.0` works fine.

Fixes #45