### PR TITLE
Implement PowerOn command

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -58,6 +58,7 @@ COMMANDS = {
     # For devices that support being turned on/off
     'power': 'Power',
     'poweroff': 'PowerOff',
+    'poweron': 'PowerOn',
 }
 
 SENSORS = ('acceleration', 'magnetic', 'orientation', 'rotation')


### PR DESCRIPTION
Add a command to send the PowerOn keypress event, alongside the
existing Power and PowerOff events.

Fixes #52