### PR TITLE
Include all successful HTTP status codes

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -224,7 +224,7 @@ class Roku(object):
         func = getattr(self._conn, method.lower())
         resp = func(url, timeout=self.timeout, *args, **kwargs)
 
-        if resp.status_code not in [200, 204]:
+        if resp.status_code < 200 or resp.status_code > 299:
             raise RokuException(resp.content)
 
         return resp.content


### PR DESCRIPTION
Fixes home-assistant/home-assistant#29591

Description:
-  include all successful http status codes instead of only two of them
- more details: https://github.com/home-assistant/home-assistant/issues/29591#issuecomment-562884172
