### PR TITLE
Add in two new methods for iterable volume control.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ To see a full list of available commands, use the *commands* property.
 If you are following along on your home network and are connected to your Roku, you should see it doing stuff. *Cool!*
 
 
-Extended Functions
+Iterable Functions
 ~~~~~~~~~~~~~~~~~~
 
 The library formerly had just two methods of volume control, and mute.

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,19 @@ To see a full list of available commands, use the *commands* property.
 If you are following along on your home network and are connected to your Roku, you should see it doing stuff. *Cool!*
 
 
+Extended Functions
+~~~~~~~~~~~~~~~~~~
+
+The library formerly had just two methods of volume control, and mute.
+:: 
+    >>> roku.volume_down()
+    >>> roku.volume_up()
+    
+There are now two additional methods which iterate over the native volume methods when provided with an int parameter.
+::
+    >>> roku.volume_down_by(3)
+    >>> roku.volume_up_by(5)
+
 Apps
 ~~~~
 

--- a/roku/core.py
+++ b/roku/core.py
@@ -60,7 +60,7 @@ COMMANDS = {
     'poweroff': 'PowerOff',
 }
 
-EXTENDED_FUNCTIONS = {
+ITERABLE_FUNCTIONS = {
     # Making the standard volume calls more iterable.
     # Accepts an integer and calls the associated function by that arg times.
     #     roku.volume_down_by(3)
@@ -169,7 +169,7 @@ class Roku(object):
 
     def __getattr__(self, name):
 
-        if name not in COMMANDS and name not in SENSORS and name not in EXTENDED_FUNCTIONS:
+        if name not in COMMANDS and name not in SENSORS and name not in ITERABLE_FUNCTIONS:
             raise AttributeError('%s is not a valid method' % name)
 
         def command(*args, **kwargs):
@@ -177,8 +177,8 @@ class Roku(object):
                 keys = ['%s.%s' % (name, axis) for axis in ('x', 'y', 'z')]
                 params = dict(zip(keys, args))
                 self.input(params)
-            elif name in EXTENDED_FUNCTIONS:
-                path = '/keypress/%s' % EXTENDED_FUNCTIONS[name]
+            elif name in ITERABLE_FUNCTIONS:
+                path = '/keypress/%s' % ITERABLE_FUNCTIONS[name]
                 for _ in range(args[0]):
                     self._post(path)
             elif name == 'literal':

--- a/roku/core.py
+++ b/roku/core.py
@@ -60,6 +60,14 @@ COMMANDS = {
     'poweroff': 'PowerOff',
 }
 
+EXTENDED_FUNCTIONS = {
+    # Making the standard volume calls more iterable.
+    # Accepts an integer and calls the associated function by that arg times.
+    #     roku.volume_down_by(3)
+    'volume_down_by': 'VolumeDown',
+    'volume_up_by': 'VolumeUp',
+}
+
 SENSORS = ('acceleration', 'magnetic', 'orientation', 'rotation')
 
 TOUCH_OPS = ('up', 'down', 'press', 'move', 'cancel')
@@ -161,7 +169,7 @@ class Roku(object):
 
     def __getattr__(self, name):
 
-        if name not in COMMANDS and name not in SENSORS:
+        if name not in COMMANDS and name not in SENSORS and name not in EXTENDED_FUNCTIONS:
             raise AttributeError('%s is not a valid method' % name)
 
         def command(*args, **kwargs):
@@ -169,6 +177,10 @@ class Roku(object):
                 keys = ['%s.%s' % (name, axis) for axis in ('x', 'y', 'z')]
                 params = dict(zip(keys, args))
                 self.input(params)
+            elif name in EXTENDED_FUNCTIONS:
+                path = '/keypress/%s' % EXTENDED_FUNCTIONS[name]
+                for _ in range(args[0]):
+                    self._post(path)
             elif name == 'literal':
                 for char in args[0]:
                     path = '/keypress/%s_%s' % (COMMANDS[name], quote_plus(char))


### PR DESCRIPTION
This allows you to jump volume incrementally by passing an integer argument to either `volume_down_by` or `volume_up_by`. 


This functionality can also be extended to `ChannelUp` and `ChannelDown` by defining `'channel_up_by': 'ChannelUp'` and `'channel_down_by': 'ChannelDown'` in the `ITERABLE_FUNCTIONS`, but I don't have a TV tuner to test those commands.

