### PR TITLE
Made _app_for_name() into fuzzy finding

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -191,7 +191,7 @@ class Roku(object):
 
     def _app_for_name(self, name):
         for app in self.apps:
-            if app.name == name:
+            if app.name.find(name) > -1:
                 return app
 
     def _app_for_id(self, app_id):


### PR DESCRIPTION
_app_for_name() used to use an equality operator to check for a match, meaning that you had to know the full and exact name of the app you wished to invoke.
This function now does a find operation on the app.name string, allowing for a partial match of the name. This has the limitation, of course, of only returning the first match.