### PR TITLE
Fix bad substitution in format string.

### DIFF
--- a/roku/discovery.py
+++ b/roku/discovery.py
@@ -36,7 +36,7 @@ def discover(timeout=2, retries=1, st=ST_ECP):
             "M-SEARCH * HTTP/1.1",
             "HOST: {0}:{1}".format(*group),
             'MAN: "ssdp:discover"',
-            "ST: {st}",
+            "ST: {0}".format(st),
             "MX: 3",
             "",
             "",


### PR DESCRIPTION
Previously, the discover function sent an incorrect value in the ST
header of the SSDP request. It is supposed to be the string "roku:ecp"
but was the string "{st}" due to incorrect use of format strings.