### PR TITLE
Support testing of Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 5
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v1

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-black = "==19.10b0"
+black = "==21.11b1"
 flake8 = "*"
 importlib-metadata = "*"
 pytest = "*"

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )


### PR DESCRIPTION
- Update GitHub workflow to test python 3.9 and 3.10. 
- Update `setup.py` to reflect python 3.9 and 3.10 support

The version of `black` was updated to support 3.10. Also `max-parallel` was incremented to 5 from 4 to support running all test python versions in parallel.