### PR TITLE
Added keydown and keyup support for commands

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,4 @@ These very nice people have helped create python-roku.
 * [bwarden](https://github.com/bwarden) - PowerOn command
 * [springstan](https://github.com/springstan) - fix for successful status codes
 * [zombielinux](https://github.com/zombielinux) - added support for hostnames
+* [kyesh](https://github.com/kyesh) - added support for keyup and keydown

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,12 @@ The Roku object has a method for each of the buttons on the remote.
     >>> roku.right()
     >>> roku.select()
 
+To support keyup and keydown events simply pass "keyup" or "keydown" when you call the command.
+::
+
+    >>> roku.right("keydown")
+    >>> roku.right("keyup")
+
 To see a full list of available commands, use the *commands* property.
 ::
 

--- a/roku/core.py
+++ b/roku/core.py
@@ -181,7 +181,10 @@ class Roku(object):
                 params = {k.replace("_", "-"): v for k, v in kwargs.items()}
                 self._post(path, params=params)
             else:
-                path = "/keypress/%s" % COMMANDS[name]
+                if(len(args)>0 and (args[0] == "keydown" or args[0] == "keyup")):
+                    path = "/%s/%s"%(args[0],COMMANDS[name])
+                else:
+                    path = "/keypress/%s" % COMMANDS[name]
                 self._post(path)
 
         return command


### PR DESCRIPTION
To support a project I am working on I need to be able to do the "keydown" and "keyup" versions of the commands. I'm making a pull request incorporating those changes so that others may use them.

- modified command method defined in __getattr__ to check if a parameter is passed. If the parameter is "keydown" or "keyup" modify the post path to use the respective parameter. Otherwise, default to "keypress".
- Updated documentation showing how to use it.
- Added my name to the list of contributors