### PR TITLE
Add support for media-player query

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -144,6 +144,24 @@ class DeviceInfo(object):
         )
 
 
+class MediaPlayer(object):
+    def __init__(
+        self,
+        state,
+        app,
+        position,
+        duration
+    ):
+        self.state = state
+        self.app = app
+        self.position = position
+        self.duration = duration
+
+    def __repr__(self):
+        return "<MediaPlayer: %s in %s at %s/%s ms>" % (
+            self.state, self.app.name, self.position, self.duration)
+
+
 class Roku(object):
     @classmethod
     def discover(self, *args, **kwargs):
@@ -276,6 +294,19 @@ class Roku(object):
             roku_type=roku_type,
         )
         return dinfo
+
+    @property
+    def media_player(self):
+        resp = self._get("/query/media-player")
+        root = ET.fromstring(resp)
+
+        mp = MediaPlayer(
+            state=root.get("state"),
+            app=self[int(root.find("plugin").get("id"))],
+            position=int(root.find("position").text.split(" ", 1)[0]),
+            duration=int(root.find("duration").text.split(" ", 1)[0]),
+        )
+        return mp
 
     @property
     def commands(self):

--- a/roku/tests/test_roku.py
+++ b/roku/tests/test_roku.py
@@ -88,6 +88,26 @@ def test_device_info(mocker, roku):
     assert d.roku_type == 'Stick'
 
 
+def test_media_player(mocker, roku):
+
+    xml_path = os.path.join(TESTS_PATH, 'responses', 'media-player.xml')
+    with open(xml_path) as infile:
+        content = infile.read()
+
+    faux_apps = (Application(33, '1.2.3', 'Faux YouTube'),)
+
+    mocked_get = mocker.patch.object(Roku, '_get')
+    mocked_get.return_value = content.encode('utf-8')
+    mocker.patch.object(Roku, 'apps', new=faux_apps)
+
+    m = roku.media_player
+
+    assert m.state == 'pause'
+    assert m.app.name == 'Faux YouTube'
+    assert m.position == 11187
+    assert m.duration == 1858000
+
+
 def test_commands(roku):
 
     for cmd in roku.commands:


### PR DESCRIPTION
The media-player query shows information like player state, the current
app from which the media is being played, as well as the duration
and position within the stream. This is useful for automation like
automatic movie room lighting and sleep timers.