### PR TITLE
Add hint for 401 Unauthorized error

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -256,6 +256,9 @@ class Roku(object):
         resp = func(url, timeout=self.timeout, *args, **kwargs)
 
         if resp.status_code < 200 or resp.status_code > 299:
+            if resp.status_code == 401:
+                raise RokuException("Please ensure that mobile / network control "
+                                    "is enabled under Settings > Advanced Settings")
             raise RokuException(resp.content)
 
         return resp.content


### PR DESCRIPTION
If the user (someone like me) has disabled remote access it can lead to confusing error messages. Help elaborate for users (like myself) that they need to change their settings to allow `python-roku` to communicate with their locked down Roku devices,